### PR TITLE
fix: undefined type in url

### DIFF
--- a/src/components/player/player.js
+++ b/src/components/player/player.js
@@ -124,7 +124,11 @@ export const openPlayerModal = (
   player.src({ src, type, keySystems });
 
   if (shouldUpdateRouter) {
-    router.updateState({ src, type, ...toParams(keySystems) });
+    router.updateState({
+      src,
+      ...(type ? { type } : {}),
+      ...toParams(keySystems)
+    });
   }
 
   return player;


### PR DESCRIPTION
## Description

Avoids adding `type=undefined` as a query parameter if no type was passed when loading a source. This bug occurred when loading a url int the examples page.

This was preventing sharing a url when a media was loaded through this form.

## Changes made

- Omits adding the type as a query parameter if its not set.
