### PR TITLE
chore(showcase): make implementation section collapsible

### DIFF
--- a/src/layout/content/examples/load-media-form-component.js
+++ b/src/layout/content/examples/load-media-form-component.js
@@ -124,17 +124,17 @@ export class LoadMediaFormComponent extends LitElement {
   }
 
   #onFormAnimationEnd(e) {
-    if (e.target.classList.contains('shrink')) {
+    if (e.target.classList.contains('fade-out-shrink')) {
       e.target.classList.remove('active');
     }
 
-    e.target.classList.remove('fade-in-grow', 'shrink');
+    e.target.classList.remove('fade-in-grow', 'fade-out-shrink');
   }
 
   #formAnimationClassMap() {
     return {
       'fade-in-grow': this.drmSettingsShown === true,
-      shrink: this.drmSettingsShown === false
+      'fade-out-shrink': this.drmSettingsShown === false
     };
   }
 

--- a/src/layout/content/examples/load-media-form-component.js
+++ b/src/layout/content/examples/load-media-form-component.js
@@ -124,10 +124,7 @@ export class LoadMediaFormComponent extends LitElement {
   }
 
   #onFormAnimationEnd(e) {
-    if (e.target.classList.contains('fade-out-shrink')) {
-      e.target.classList.remove('active');
-    }
-
+    e.target.classList.toggle('active', !e.target.classList.contains('fade-out-shrink'));
     e.target.classList.remove('fade-in-grow', 'fade-out-shrink');
   }
 

--- a/src/layout/content/examples/load-media-form-component.scss
+++ b/src/layout/content/examples/load-media-form-component.scss
@@ -36,26 +36,3 @@
 .load-bar-action {
   width: 100%;
 }
-
-
-.fade-in-grow {
-  opacity: 0;
-  animation: fade-in .4s var(--ease-elastic-in-3) forwards,
-  grow .4s ease;
-}
-
-.shrink {
-  opacity: 0;
-  animation: grow .4s ease;
-  animation-direction: reverse;
-}
-
-@keyframes grow {
-  from {
-    max-height: 0;
-  }
-
-  to {
-    max-height: var(--size-15);
-  }
-}

--- a/src/layout/content/showcase/showcase-component.scss
+++ b/src/layout/content/showcase/showcase-component.scss
@@ -11,12 +11,27 @@
   border-left: 3px solid var(--color-5);
 }
 
+[part="implementation-toggle"] {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+
+  i {
+    margin-right: var(--size-1);
+  }
+}
+
 [part="implementation"] {
+  display: none;
   margin-bottom: var(--size-4);
   background-color: var(--color-10);
   border: 2px solid var(--color-5);
   border-radius: var(--radius-1);
   box-shadow: var(--inner-shadow-4);
+
+  &.active {
+    display: block;
+  }
 }
 
 [part="implementation-code"] {

--- a/src/theme/animations.scss
+++ b/src/theme/animations.scss
@@ -18,3 +18,25 @@
   animation: fade-in .4s var(--ease-elastic-in-3) forwards,
              slide-in-up .4s var(--ease-elastic-in-3);
 }
+
+.fade-in-grow {
+  opacity: 0;
+  animation: fade-in .4s var(--ease-elastic-in-3) forwards,
+  grow .4s ease;
+}
+
+.fade-out-shrink {
+  opacity: 0;
+  animation: fade-in .4s var(--ease-elastic-in-3) forwards, grow .4s ease;
+  animation-direction: reverse;
+}
+
+@keyframes grow {
+  from {
+    max-height: 0;
+  }
+
+  to {
+    max-height: var(--size-15);
+  }
+}


### PR DESCRIPTION
## Description

Resolves #2 by making each showcase's implementation section individually collapsible.

- Added a `visibility` icon from material icons as a visual cue next to each showcase section title.
- Modified the text to display "Show the implementation" when the section is collapsed and "Hide the implementation" when expanded.
- Added an animation to ease the visual feedback.

## Changes made

- Moves the growing and shrink animation from the `load-media-form-component` stylesheet to the theme's animation stylesheet. Added fading out for the shrinking animation to match its reverse and renamed it: `fade-out-shrink`.

## Screenshots

| ![Expanded implementation section](https://github.com/SRGSSR/pillarbox-web-demo/assets/11271371/09edc1db-a717-427e-a1f2-66e9bccfd803) | ![Colapsed implementation section](https://github.com/SRGSSR/pillarbox-web-demo/assets/11271371/d1b6b884-a7fb-4b78-a66d-347785316589) |
|:--------------------------------------------------------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------------------------------:|
|                          Expanded implementation section                                                            |                             Colapsed implementation section                                                            |