### PR TITLE
fix: avoid triggering multiple animationend events

### DIFF
--- a/src/theme/animations.scss
+++ b/src/theme/animations.scss
@@ -16,18 +16,17 @@
 .slide-up-fade-in {
   opacity: 0;
   animation: fade-in .4s var(--ease-elastic-in-3) forwards,
-             slide-in-up .4s var(--ease-elastic-in-3);
+  slide-in-up .4s var(--ease-elastic-in-3) infinite;
 }
 
 .fade-in-grow {
   opacity: 0;
-  animation: fade-in .4s var(--ease-elastic-in-3) forwards,
-  grow .4s ease;
+  animation: fade-in .4s var(--ease-elastic-in-3) forwards, grow .4s ease infinite;
 }
 
 .fade-out-shrink {
   opacity: 0;
-  animation: fade-in .4s var(--ease-elastic-in-3) forwards, grow .4s ease;
+  animation: fade-in .4s var(--ease-elastic-in-3) forwards, grow .4s ease infinite;
   animation-direction: reverse;
 }
 


### PR DESCRIPTION
## Description

To prevent the triggering of multiple `animationend` events, a fix has been implemented for combined animations such as: `fade-in-grow`, `fade-out-shrink` and `slide-up-fade-in`. Previously, an `animationend` event would be triggered for each individual animation, leading to unexpected behavior. 

## Changes made

- Added `infinite` iteration count in one of the animations, ensuring that only a single `animationend` event is triggered.