### PR TITLE
style: adjust menu and showcases presentation

### DIFF
--- a/src/layout/content/showcase/showcase-page.scss
+++ b/src/layout/content/showcase/showcase-page.scss
@@ -22,3 +22,7 @@ a {
     border-color: var(--color-9);
   }
 }
+
+div {
+  margin-top: var(--size-7);
+}

--- a/src/layout/header/demo-header-component.scss
+++ b/src/layout/header/demo-header-component.scss
@@ -9,7 +9,7 @@ li {
 }
 
 route-link::part(a) {
-  padding: var(--size-1) var(--size-1);
+  padding: var(--size-1) var(--size-2);
   font-size: var(--size-4);
   border-radius: var(--radius-3);
   transition: background-color 0.4s, color 0.4s;


### PR DESCRIPTION
## Description

Adds padding to the menu links and more space between showcase sections.

## Changes made

| Before | After |
| -------| ------|
| ![Before](https://github.com/SRGSSR/pillarbox-web-demo/assets/11271371/eb9f2e31-b830-483a-96b6-18151aa1e6ba) | ![After](https://github.com/SRGSSR/pillarbox-web-demo/assets/11271371/2ad87089-835a-4836-9d70-78b1c900dde0) |