### PR TITLE
feat(settings): add data provider host setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "vite build",
     "eslint": "eslint src/**",
     "outdated": "npm outdated",
-    "start": "vite --port 9696",
+    "start": "vite --port 9696 --host",
     "stylelint": "stylelint **/*.{css,scss,js}",
     "stylelint:fix": "stylelint **/*.{css,scss,js} --fix",
     "prepare": "husky"

--- a/src/components/player/player.js
+++ b/src/components/player/player.js
@@ -8,6 +8,7 @@ import PreferencesProvider
   from '../../layout/content/settings/preferences-provider';
 import router from '../../router/router';
 import Pillarbox from '@srgssr/pillarbox-web';
+import { IL_DEFAULT_HOST } from '../../utils/il-provider.js';
 
 const DEMO_PLAYER_ID = 'player';
 const DEFAULT_OPTIONS = {
@@ -30,7 +31,10 @@ const createPlayer = (options = {}) => {
     ...{
       muted: preferences.muted ?? true,
       autoplay: preferences.autoplay ?? false,
-      debug: preferences.debug ?? false
+      debug: preferences.debug ?? false,
+      srgOptions: {
+        dataProviderHost: preferences.dataProviderHost ?? IL_DEFAULT_HOST
+      }
     },
     ...options
   });

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,14 @@ import './layout/content/showcase/showcase-page';
 import './layout/header/demo-header-component.js';
 import './router/route-outlet-component';
 import router from './router/router';
-import PreferencesProvider from './layout/content/settings/preferences-provider';
+import PreferencesProvider
+  from './layout/content/settings/preferences-provider';
+import ilProvider from './utils/il-provider.js';
 
+// Load preferences and initializes il host
 const preferences = PreferencesProvider.loadPreferences();
+
+ilProvider.host = preferences.dataProviderHost;
 
 // Initialize the router with the current path or 'examples' if none is found
 router.start({ defaultPath: 'examples' });

--- a/src/layout/content/settings/settings-page.scss
+++ b/src/layout/content/settings/settings-page.scss
@@ -3,7 +3,7 @@
   padding: var(--size-3) 0;
 }
 
-[part="toggle-container"] {
+[part="toggle-container"], [part="input-container"] {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -25,16 +25,27 @@
 }
 
 [part="label"] {
-  flex: 1;
   line-height: var(--size-8);
-  cursor: pointer;
   padding-inline: var(--size-3);
 }
 
+[part="toggle-container"] [part="label"] {
+  flex: 1;
+  cursor: pointer;
+}
 
 [part="toggle-switch"] {
   display: flex;
   align-items: center;
   height: var(--size-8);
   padding-inline: var(--size-3);
+}
+
+[part="input"] {
+  flex: 1;
+  margin: 0;
+  padding: var(--size-1) var(--size-3);
+  text-align: right;
+  background-color: var(--color-9);
+  border-bottom-right-radius: var(--radius-3);
 }

--- a/src/theme/theme.scss
+++ b/src/theme/theme.scss
@@ -73,7 +73,7 @@ h3 {
   font-size: var(--size-3);
 }
 
-input[type="text"], select {
+input, select {
   margin: var(--size-1) 0 0 0;
   padding: var(--size-4) var(--size-3);
   color: var(--color-2);
@@ -85,6 +85,7 @@ input[type="text"], select {
 
 select {
   cursor: pointer;
+  appearance: none;
 }
 
 select:required:invalid {

--- a/src/utils/il-provider.js
+++ b/src/utils/il-provider.js
@@ -1,4 +1,5 @@
-const IL_DEFAULT_HOST = 'il.srgssr.ch';
+export const IL_DEFAULT_HOST = 'il.srgssr.ch';
+
 const DEFAULT_QUERY_PARAMS = {
   vector: 'srgplay'
 };
@@ -25,13 +26,34 @@ const toMedia = ({ title, urn, mediaType, date, duration }) => ({
  * @class
  */
 class ILProvider {
+  #host;
+
   /**
    * Creates an instance of ILProvider.
    *
-   * @param {string} [hostName='il.srgssr.ch'] - The hostname for the integration layer (without the protocol).
+   * @param {string} [host='il.srgssr.ch'] - The hostname for the integration layer (without the protocol).
    */
-  constructor(hostName = IL_DEFAULT_HOST) {
-    this.baseUrl = `${hostName}/integrationlayer/2.0`;
+  constructor(host = IL_DEFAULT_HOST) {
+    this.host = host;
+  }
+
+  /**
+   * Get the current hostname for the integration layer.
+   *
+   * @returns {string} the hostname for the integration layer.
+   */
+  get host() {
+    return this.#host;
+  }
+
+  /**
+   * Set the hostname for the integration layer (without the protocol). Forces
+   * `il.srgssr.ch` if null, undefined or empty string is passed.
+   *
+   * @param {string} host The hostname for the integration layer,
+   */
+  set host(host) {
+    this.#host = host || IL_DEFAULT_HOST;
   }
 
   /**
@@ -311,7 +333,7 @@ class ILProvider {
    */
   async #fetch(path, params = DEFAULT_QUERY_PARAMS, signal = undefined) {
     const queryParams = new URLSearchParams(params).toString();
-    const url = `https://${this.baseUrl}/${path.replace(/^\/+/, '')}?${queryParams}`;
+    const url = `https://${this.host}/integrationlayer/2.0/${path.replace(/^\/+/, '')}?${queryParams}`;
 
     return fetch(url, { signal }).then(response => {
       if (!response.ok) {


### PR DESCRIPTION
## Description

This feature enhances the demo application's configurability by allowing users to specify a custom data provider host via the settings page. This flexibility is crucial for adapting the application to different data sources and environments.

## Changes made

- **Data Provider Host Setting:** Introduced an input field on the settings page for changing the data provider host. This setting is propagated throughout the demo, affecting the player and integration layer callbacks (for the search and list views). The new setting is saved in local storage.
- Reduced specificity of the theme's input styles to simplify overriding the style.
- Applied `appearance: none` to select elements. In Safari browsers this hide default browser-specific appearances, which was showing up until now.
