### PR TITLE
fix(style): avoid menu items wrapping

### DIFF
--- a/src/layout/header/demo-header-component.scss
+++ b/src/layout/header/demo-header-component.scss
@@ -4,10 +4,6 @@ ul, li {
   list-style: none;
 }
 
-li {
-  display: inline-block;
-}
-
 route-link::part(a) {
   padding: var(--size-1) var(--size-2);
   font-size: var(--size-4);
@@ -43,13 +39,10 @@ core-demo-header {
 }
 
 nav ul {
+  display: flex;
   margin-bottom: var(--size-4);
 
   li {
-    margin-right: var(--size-1);
-  }
-
-  li:last-child {
     margin: 0;
   }
 }


### PR DESCRIPTION
## Description

Fixes the menu item wrapping by adjusting the margin between items and using a flex box on the parent element.

| Before | After |
|--------|-------|
| <img src="https://github.com/SRGSSR/pillarbox-web-demo/assets/11271371/09a3bce6-b82d-42f4-917c-6199f82c1aee" height="300"> | <img src="https://github.com/SRGSSR/pillarbox-web-demo/assets/11271371/e600ecee-86c2-4020-a8c2-69477cfd1e3b" height="300"> |
