### PR TITLE
chore: enable direct video playback from play urls

### DIFF
--- a/src/layout/content/examples/load-media-form-component.js
+++ b/src/layout/content/examples/load-media-form-component.js
@@ -37,8 +37,16 @@ export class LoadMediaFormComponent extends LitElement {
     };
   }
 
+  #getSource() {
+    try {
+      return new URL(this.src).searchParams.get('urn') ?? this.src;
+    } catch (error) {
+      return this.src;
+    }
+  }
+
   #submitMedia() {
-    const src = this.src;
+    const src = this.#getSource();
     const type = src.startsWith('urn:') ? 'srgssr/urn' : undefined;
     const keySystems = this.#keySystems;
 


### PR DESCRIPTION
## Description

Resolves #29 by extracting the URN query parameter from PLAY URLs pasted into the main input on the example page. The application now initiates video playback using the extracted URN.
