### PR TITLE
feat(showcase): add playlist example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@srgssr/pillarbox-playlist": "^1.0.0",
         "@srgssr/pillarbox-web": "^1.12.1",
         "@srgssr/skip-button": "^1.0.0",
         "highlight.js": "^11.9.0",
@@ -1698,6 +1699,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@srgssr/pillarbox-playlist": {
+      "version": "1.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@srgssr/pillarbox-playlist/1.0.0/689f77199fcc3f57ed69b7864b8295ce679d0a4a",
+      "integrity": "sha512-2AHitC7Cjn/n+8NURZ/ud/h+kG+kBOSYEQHxFYT2U0P4p2SPuIPy9YWb73AzHpKvycn0jxhos2A/jELGVUXSmA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "video.js": "^8.0.0"
+      }
     },
     "node_modules/@srgssr/pillarbox-web": {
       "version": "1.12.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "vite": "^5.2.11"
   },
   "dependencies": {
+    "@srgssr/pillarbox-playlist": "^1.0.0",
     "@srgssr/pillarbox-web": "^1.12.1",
     "@srgssr/skip-button": "^1.0.0",
     "highlight.js": "^11.9.0",

--- a/src/layout/content/showcase/showcase-page.js
+++ b/src/layout/content/showcase/showcase-page.js
@@ -9,6 +9,7 @@ import rawMultiPlayerExample from '../../../../static/showcases/multi-player.htm
 import rawDetectBlockedSegmentsExample from '../../../../static/showcases/blocked-segment.html?raw';
 import rawDisplayCurrentChapterExample from '../../../../static/showcases/chapters.html?raw';
 import rawSkipCreditsExample from '../../../../static/showcases/skip-credits.html?raw';
+import rawPlaylistExample from '../../../../static/showcases/playlist.html?raw';
 import { getTextFromHTML } from './example-parser.js';
 
 const startTimeExampleTxt = getTextFromHTML(rawStartTimeExample);
@@ -18,6 +19,7 @@ const detectBlockedSegmentsExampleTxt =
 const displayCurrentChapterExampleTxt =
   getTextFromHTML(rawDisplayCurrentChapterExample);
 const skipCreditsExampleTxt = getTextFromHTML(rawSkipCreditsExample);
+const playlistExampleTxt = getTextFromHTML(rawPlaylistExample);
 
 export class ShowCasePage extends LitElement {
   static styles = [theme, animations, unsafeCSS(showcasePageCss)];
@@ -29,6 +31,7 @@ export class ShowCasePage extends LitElement {
       ${this.#renderDetectBlockedSegments()}
       ${this.#renderDisplayCurrentChapter()}
       ${this.#renderSkipCredits()}
+      ${this.#renderPlaylist()}
     `;
   }
 
@@ -130,6 +133,26 @@ export class ShowCasePage extends LitElement {
           <code-block slot="code" language="javascript">${skipCreditsExampleTxt}</code-block>
         </showcase-component>
         <a part="showcase-link" href="./static/showcases/skip-credits.html" target="_blank">
+          Open this showcase
+        </a>
+      </div>
+    `;
+  }
+
+  #renderPlaylist() {
+    return html`
+      <div class="fade-in"
+           @animationend="${e => e.target.classList.remove('fade-in')}">
+        <showcase-component href="playlist.html">
+          <h2 slot="title">Playlist</h2>
+          <p slot="description">
+            This example show how to fetch media data for a set of video sources 
+            and load them into the <a href="https://github.com/SRGSSR/pillarbox-web-suite/tree/main/packages/pillarbox-playlist#readme" target="_blank">Pillarbox Playlist plugin</a>
+            with metadata such as title and duration.
+          </p>
+          <code-block slot="code" language="javascript">${playlistExampleTxt}</code-block>
+        </showcase-component>
+        <a part="showcase-link" href="./static/showcases/playlist.html" target="_blank">
           Open this showcase
         </a>
       </div>

--- a/src/layout/content/showcase/showcase-page.scss
+++ b/src/layout/content/showcase/showcase-page.scss
@@ -27,6 +27,10 @@ div {
   margin-top: var(--size-7);
 }
 
+div:last-child {
+  margin-bottom: var(--size-7);
+}
+
 a {
   font-size: inherit;
 }

--- a/static/showcases/blocked-segment.html
+++ b/static/showcases/blocked-segment.html
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Pillarbox Demo - Detect blocked segment</title>
   <link rel="icon" type="image/x-icon" href="../../img/favicon.ico">
-  <link rel="stylesheet" href="./static-showcase.scss"/>
   <link rel="stylesheet" href="./blocked-segment.scss"/>
 </head>
 

--- a/static/showcases/blocked-segment.scss
+++ b/static/showcases/blocked-segment.scss
@@ -1,3 +1,5 @@
+@import './static-showcase';
+
 .pbw-blocked-segment-notification {
   position: absolute;
   right: var(--size-5);

--- a/static/showcases/chapters-showcase.scss
+++ b/static/showcases/chapters-showcase.scss
@@ -1,3 +1,5 @@
+@import './static-showcase';
+
 .pbw-current-chapter {
   position: absolute;
   top: calc(var(--size-8) * -1);

--- a/static/showcases/chapters.html
+++ b/static/showcases/chapters.html
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Pillarbox Demo - Display Current Chapter</title>
   <link rel="icon" type="image/x-icon" href="../../img/favicon.ico">
-  <link rel="stylesheet" href="./static-showcase.scss"/>
   <link rel="stylesheet" href="./chapters-showcase.scss"/>
 </head>
 

--- a/static/showcases/playlist-showcase.scss
+++ b/static/showcases/playlist-showcase.scss
@@ -1,1 +1,2 @@
+@import './static-showcase';
 @import '@srgssr/pillarbox-playlist/dist/pillarbox-playlist.min.css';

--- a/static/showcases/playlist-showcase.scss
+++ b/static/showcases/playlist-showcase.scss
@@ -1,0 +1,1 @@
+@import '@srgssr/pillarbox-playlist/dist/pillarbox-playlist.min.css';

--- a/static/showcases/playlist.html
+++ b/static/showcases/playlist.html
@@ -4,9 +4,8 @@
   <meta charset="UTF-8"/>
   <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Pillarbox Demo - Skip Credits</title>
+  <title>Pillarbox Demo - Playlist</title>
   <link rel="icon" type="image/x-icon" href="../../img/favicon.ico">
-  <link rel="stylesheet" href="./static-showcase.scss"/>
   <link rel="stylesheet" href="./playlist-showcase.scss"/>
 </head>
 

--- a/static/showcases/playlist.html
+++ b/static/showcases/playlist.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Pillarbox Demo - Skip Credits</title>
+  <link rel="icon" type="image/x-icon" href="../../img/favicon.ico">
+  <link rel="stylesheet" href="./static-showcase.scss"/>
+  <link rel="stylesheet" href="./playlist-showcase.scss"/>
+</head>
+
+<body>
+<core-demo-header></core-demo-header>
+<div class="showcase-content">
+  <h2>Playlist</h2>
+  <div class="video-container">
+    <video-js id="video-element-id" class="pillarbox-js" controls crossorigin="anonymous"></video-js>
+  </div>
+
+  <button class="showcase-btn" id="close-btn">Close this window</button>
+</div>
+
+<script type="module" data-implementation>
+  // Import the pillarbox library and the SrgSsr utility class
+  import { default as pillarbox, SrgSsr } from '@srgssr/pillarbox-web';
+  // Import the playlist plugin for pillarbox
+  import '@srgssr/pillarbox-playlist';
+  // Import the playlist UI plugin for pillarbox
+  import '@srgssr/pillarbox-playlist/ui';
+
+  // Create a pillarbox player instance with the playlist plugin
+  const player = pillarbox('video-element-id', {
+    // Activate autoplay to automatically start the next element
+    autoplay: true,
+    plugins: {
+      // Configure the playlist plugin
+      pillarboxPlaylist: { autoadvance: true, repeat: true },
+      // Configure the playlist UI plugin and specify where to insert it in the UI
+      pillarboxPlaylistUI: { insertChildBefore: 'fullscreenToggle' }
+    }
+  });
+
+  // Define an array of video sources
+  const sources = [
+    'urn:rts:video:14827742',
+    'urn:srf:video:05457f66-fd67-4131-8e0a-6d85743efc39',
+    'urn:rtr:video:33136b80-bec6-40cd-a771-b8954c805098',
+    'urn:rts:video:9883196',
+  ];
+
+  Promise.all(sources.map(async urn => {
+    // Fetch the media composition data for each URN
+    const mediaComposition = await SrgSsr.getMediaComposition(urn, SrgSsr.dataProvider(player));
+    // Get the main chapter of the media composition
+    const mainChapter = mediaComposition.getMainChapter();
+
+    return {
+      // Define the sources of this playlist item URL and type
+      sources: [{ src: urn, type: 'srgssr/urn' }],
+      // Define the title and duration in seconds
+      data: { title: mainChapter.title, duration: mainChapter.duration / 1000 },
+      // Define the poster image
+      poster: mainChapter.imageUrl
+    };
+  })).then(playlist => {
+    // Load the playlist
+    player.pillarboxPlaylist().load(playlist);
+  });
+</script>
+
+<script type="module">
+  import pillarbox from '@srgssr/pillarbox-web';
+  import '../../src/layout/header/core-demo-header-component.js';
+
+  document.querySelector('#close-btn').addEventListener('click', () => {
+    window.close();
+  });
+
+  window.pillarbox = pillarbox;
+</script>
+
+</body>
+</html>

--- a/static/showcases/skip-credits.html
+++ b/static/showcases/skip-credits.html
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Pillarbox Demo - Skip Credits</title>
   <link rel="icon" type="image/x-icon" href="../../img/favicon.ico">
-  <link rel="stylesheet" href="./static-showcase.scss"/>
   <link rel="stylesheet" href="./skip-showcase.scss"/>
 </head>
 

--- a/static/showcases/skip-showcase.scss
+++ b/static/showcases/skip-showcase.scss
@@ -1,1 +1,2 @@
+@import './static-showcase';
 @import '@srgssr/skip-button/dist/skip-button.min.css';


### PR DESCRIPTION
## Description

Introduces a playlist example using the `@srgssr/pillarbox-playlist` plugin.

In the example player is configured with the playlist plugins, and showcases how to fetch the media data fetches media data for a set of predefined video sources, loading them into the player's playlist with metadata.

## Changes Made

- Import a single stylesheet in the showcases to avoid vite optimisation to mixing the declared order of import.