### PR TITLE
chore: remove crossorigin attribute from video-js tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 
 <body>
 <demo-dialog>
-  <video-js id="demo-player" class="pillarbox-js" controls crossorigin="anonymous"></video-js>
+  <video-js id="demo-player" class="pillarbox-js" controls></video-js>
 </demo-dialog>
 
 <demo-header></demo-header>

--- a/static/showcases/blocked-segment.html
+++ b/static/showcases/blocked-segment.html
@@ -15,7 +15,7 @@
 <div class="showcase-content">
   <h2>Detect blocked segment</h2>
   <div class="video-container">
-    <video-js id="video-element-id" class="pillarbox-js" controls crossorigin="anonymous"></video-js>
+    <video-js id="video-element-id" class="pillarbox-js" controls></video-js>
   </div>
 
   <button class="showcase-btn" id="close-btn">Close this window</button>

--- a/static/showcases/chapters.html
+++ b/static/showcases/chapters.html
@@ -15,7 +15,7 @@
 <div class="showcase-content">
   <h2>Display Current Chapter</h2>
   <div class="video-container">
-    <video-js id="video-element-id" class="pillarbox-js" controls crossorigin="anonymous"></video-js>
+    <video-js id="video-element-id" class="pillarbox-js" controls></video-js>
   </div>
 
   <button class="showcase-btn" id="close-btn">Close this window</button>

--- a/static/showcases/multi-player.html
+++ b/static/showcases/multi-player.html
@@ -15,13 +15,13 @@
   <h2>Multiple players</h2>
 
   <div class="video-container">
-    <video-js id="main-player" class="pillarbox-js" controls crossorigin="anonymous"></video-js>
+    <video-js id="main-player" class="pillarbox-js" controls></video-js>
   </div>
 
   <button class="showcase-btn" id="toggle-player">Toggle main player</button>
 
   <div class="video-container">
-    <video-js id="second-player" class="pillarbox-js" controls crossorigin="anonymous"></video-js>
+    <video-js id="second-player" class="pillarbox-js" controls></video-js>
   </div>
 
   <button class="showcase-btn" id="close-btn">Close this window</button>

--- a/static/showcases/skip-credits.html
+++ b/static/showcases/skip-credits.html
@@ -15,7 +15,7 @@
 <div class="showcase-content">
   <h2>Skip Credits</h2>
   <div class="video-container">
-    <video-js id="video-element-id" class="pillarbox-js" controls crossorigin="anonymous"></video-js>
+    <video-js id="video-element-id" class="pillarbox-js" controls></video-js>
   </div>
 
   <button class="showcase-btn" id="close-btn">Close this window</button>

--- a/static/showcases/start-time.html
+++ b/static/showcases/start-time.html
@@ -14,7 +14,7 @@
 <div class="showcase-content">
   <h2>Start the player at a given position</h2>
   <div class="video-container">
-    <video-js id="video-element-id" class="pillarbox-js" controls crossorigin="anonymous"></video-js>
+    <video-js id="video-element-id" class="pillarbox-js" controls></video-js>
   </div>
 
   <button class="showcase-btn" id="close-btn">Close this window</button>


### PR DESCRIPTION
## Description

Removes the `crossorigin="anonymous"` attribute from the <video-js> tag because we were experiencing issues with cross-origin media.
