### PR TITLE
chore: update urls for custom domain setup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ This is a demo application for the [pillarbox-web](https://github.com/SRGSSR/pil
 SDK that extends the functionality of video.js. You can use this demo to see how `pillarbox-web`
 works and how to integrate it into your own web projects.
 
-The latest demo build is also accessible here: https://srgssr.github.io/pillarbox-web-demo/
+The latest demo build is also accessible here: https://demo.pillarbox.ch
 
 ## Requirements
 

--- a/public/404.html
+++ b/public/404.html
@@ -22,7 +22,7 @@
     // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
     // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
     // Otherwise, leave pathSegmentsToKeep as 0.
-    var pathSegmentsToKeep = 1;
+    var pathSegmentsToKeep = 0;
 
     var l = window.location;
     l.replace(


### PR DESCRIPTION
## Description

Use custom domain urls throughout the documentation and  update redirect configuration for custom domain compatibility.

## Changes made

- Updated all URLs to the demo page to point to `demo.pillarbox.ch`
- Updated all API documentation URLs to point to `web.pillarbox.ch/api`
- Updated all URLs to the theme editor to point to `editor.pillarbox.ch`
- Updated all URLs to the web suite demo to point to `plugins.pillarbox.ch`
- Updated all URLs to the marketing page to point to `www.pillarbox.ch`
- Updated all URLs to the Android documentation page to point to `android.pillarbox.ch`
- Adjusted `pathSegmentsToKeep` to 0 in 404.html since we're now using a custom domain. This ensures URL paths are correctly redirected on GitHub Pages, preserving single-page app functionality without breaking the root path structure.