### PR TITLE
feat: add an example to hide the PiP button on Firefox

### DIFF
--- a/src/layout/content/showcase/showcase-page.js
+++ b/src/layout/content/showcase/showcase-page.js
@@ -14,6 +14,7 @@ import rawqualityMenuExample from '../../../../static/showcases/quality-menu.htm
 import rawCountdown from '../../../../static/showcases/countdown.html?raw';
 import rawPlaybackRate from '../../../../static/showcases/playback-rate.html?raw';
 import rawChapterSelection from '../../../../static/showcases/chapter-selection.html?raw';
+import rawFirefoxPiP from '../../../../static/showcases/firefox-pip.html?raw';
 import { getTextFromHTML } from './example-parser.js';
 
 const startTimeExampleTxt = getTextFromHTML(rawStartTimeExample);
@@ -28,6 +29,7 @@ const qualityMenuExampleTxt = getTextFromHTML(rawqualityMenuExample);
 const countdownExampleTxt = getTextFromHTML(rawCountdown);
 const playbackRateExampleTxt = getTextFromHTML(rawPlaybackRate);
 const chapterSelectionExampleTxt = getTextFromHTML(rawChapterSelection);
+const FirefoxPiPExampleTxt = getTextFromHTML(rawFirefoxPiP);
 
 export class ShowCasePage extends LitElement {
   static styles = [theme, animations, unsafeCSS(showcasePageCss)];
@@ -44,6 +46,7 @@ export class ShowCasePage extends LitElement {
       ${this.#renderCountdown()}
       ${this.#renderPlaybackRate()}
       ${this.#renderChapterSelection()}
+      ${this.#renderFirefoxPiP()}
     `;
   }
 
@@ -239,6 +242,24 @@ export class ShowCasePage extends LitElement {
           <code-block slot="code" language="javascript">${chapterSelectionExampleTxt}</code-block>
         </showcase-component>
         <a part="showcase-link" href="./static/showcases/chapter-selection.html" target="_blank">
+          Open this showcase
+        </a>
+      </div>
+    `;
+  }
+
+  #renderFirefoxPiP() {
+    return html`
+      <div class="fade-in"
+           @animationend="${e => e.target.classList.remove('fade-in')}">
+        <showcase-component href="firefox-pip.html">
+          <h2 slot="title">Hide Firefox PiP Button</h2>
+          <p slot="description">
+            In this showcase, we'll demonstrate how to hide Firefox PiP Button. Activating or deactivating PiP in Firefox applies at the next player resize, such as when entering full screen mode. This appears to be due to an implementation bug in Firefox. Refer to the <a href="https://github.com/SRGSSR/pillarbox-web-demo/pull/57" target="_blank">PR</a> for more details.
+          </p>
+          <code-block slot="code" language="javascript">${FirefoxPiPExampleTxt}</code-block>
+        </showcase-component>
+        <a part="showcase-link" href="./static/showcases/firefox-pip.html" target="_blank">
           Open this showcase
         </a>
       </div>

--- a/static/showcases/firefox-pip.html
+++ b/static/showcases/firefox-pip.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pillarbox Demo - Hide Firefox PiP Button</title>
+    <link rel="icon" type="image/x-icon" href="../../img/favicon.ico">
+    <link rel="stylesheet" href="./firefox-pip.scss" />
+  </head>
+
+  <body>
+    <core-demo-header></core-demo-header>
+    <div class="showcase-content">
+      <h2>Hide Firefox PiP Button</h2>
+      <div class="video-container">
+        <video-js id="video-element-id" class="pillarbox-js" controls></video-js>
+      </div>
+
+      <button class="showcase-btn" id="close-btn">Close this window</button>
+    </div>
+
+    <script type="module" data-implementation>
+      // Import the pillarbox library
+      import pillarbox from '@srgssr/pillarbox-web';
+
+      const player = pillarbox(
+        'video-element-id',
+        {
+          fill: true,
+          muted: true,
+          // For Firefox compatibility refer to https://caniuse.com/mdn-api_htmlvideoelement_disablepictureinpicture
+          disablePictureInPicture: pillarbox.browser.IS_FIREFOX
+        }
+      );
+
+      player.src({ src: 'urn:rts:video:9883196', type: 'srgssr/urn' });
+
+      window.player = player;
+    </script>
+
+    <script type="module">
+      import pillarbox from '@srgssr/pillarbox-web';
+      import '../../src/layout/header/core-demo-header-component.js';
+
+      document.querySelector('#close-btn').addEventListener('click', () => {
+        window.close();
+      });
+
+      window.pillarbox = pillarbox;
+    </script>
+
+  </body>
+
+</html>

--- a/static/showcases/firefox-pip.scss
+++ b/static/showcases/firefox-pip.scss
@@ -1,0 +1,1 @@
+@import './static-showcase';


### PR DESCRIPTION
## Description

Shows how to hide the PiP button on Firefox to meet certain use cases.

## Changes made

- Disables PiP via a configuration option

## Edge case

When disabled on the fly Firefox seems to have difficulty applying the change unless the browser is resized.

https://github.com/user-attachments/assets/49c5cf26-3625-40ae-8d34-7c558c5b114a

https://github.com/user-attachments/assets/57944c3c-8579-4a0c-a4ba-79785af0d405





