### PR TITLE
fix(example): replace Telegiornale Flash URN with a working one

### DIFF
--- a/src/layout/content/examples/examples.js
+++ b/src/layout/content/examples/examples.js
@@ -24,7 +24,7 @@ const EXAMPLES = {
     {
       title: 'Superfluously token-protected video',
       description: 'Telegiornale flash',
-      src: 'urn:rsi:video:15916771',
+      src: 'urn:rsi:video:2660088',
       type: 'srgssr/urn'
     },
     {


### PR DESCRIPTION
## Description

The current Telegiornale Flash example does not work anymore (a 404 is returned). This PR updates it with a new URN.

## Changes made

- Replace the non-working URN for Telegiornale Flash with a new URN.