### PR TITLE
fix(player): expose videojs globally

### DIFF
--- a/src/components/player/player.js
+++ b/src/components/player/player.js
@@ -50,6 +50,8 @@ const destroyPlayer = () => {
   window.player = null;
 };
 
+// Expose videojs to avoid breaking Commander's Act
+window.videojs = Pillarbox;
 // Expose Pillarbox and player in the window object for debugging
 window.pillarbox = Pillarbox;
 // Configure the dialog


### PR DESCRIPTION
## Description

Exposes the Pillarbox instance as `window.videojs` to ensure compatibility with Commander's Act integration.

## Changes made

- add videojs to the window object