### PR TITLE
chore: change default urn for skip credits demo

### DIFF
--- a/static/showcases/skip-credits.html
+++ b/static/showcases/skip-credits.html
@@ -30,7 +30,7 @@
   const player = pillarbox('video-element-id', { SkipButton: true });
 
   // Load the video source for the player
-  player.src({ src: 'urn:rts:video:14683290', type: 'srgssr/urn' });
+  player.src({ src: 'urn:rts:video:15532586', type: 'srgssr/urn' });
 </script>
 
 <script type="module">


### PR DESCRIPTION
## Description

Change the default media of the skip-button demo for one that has the correct metadata.

