### PR TITLE
chore: mute all content by default

### DIFF
--- a/static/showcases/blocked-segment.html
+++ b/static/showcases/blocked-segment.html
@@ -89,6 +89,7 @@
   // Create a pillarbox player instance with the blockedSegmentNotification plugin
   const player = pillarbox(
     'video-element-id', {
+      muted: true,
       plugins: {
         blockedSegmentNotification: {
           delay: 5000, // Delay in milliseconds before hiding the notification

--- a/static/showcases/chapter-selection.html
+++ b/static/showcases/chapter-selection.html
@@ -27,7 +27,7 @@
   // Create a pillarbox player instance with the currentChapter plugin
   window.player = pillarbox(
     'video-element-id',
-    {muted: true}
+    { muted: true }
   );
 
   // Listen for a chapter change

--- a/static/showcases/chapters.html
+++ b/static/showcases/chapters.html
@@ -92,7 +92,10 @@
   // Create a pillarbox player instance with the currentChapter plugin
   const player = pillarbox(
     'video-element-id',
-    { plugins: { currentChapter: true } }
+    {
+      muted: true,
+      plugins: { currentChapter: true }
+    }
   );
 
   // Set the video source for the player

--- a/static/showcases/countdown.html
+++ b/static/showcases/countdown.html
@@ -166,6 +166,7 @@
       const player = pillarbox(
         'video-element-id',
         {
+          muted: true,
           fill: true,
           // Add the countdown component to the player
           countdown: true,

--- a/static/showcases/playlist.html
+++ b/static/showcases/playlist.html
@@ -32,6 +32,7 @@
   const player = pillarbox('video-element-id', {
     // Activate autoplay to automatically start the next element
     autoplay: true,
+    muted: true,
     plugins: {
       // Configure the playlist plugin
       pillarboxPlaylist: { autoadvance: true, repeat: true },

--- a/static/showcases/quality-menu.html
+++ b/static/showcases/quality-menu.html
@@ -26,7 +26,13 @@
   import 'videojs-contrib-quality-menu';
 
   // Create a pillarbox player instance with the quality menu plugin
-  const player = pillarbox('video-element-id', { plugins: { qualityMenu: true } });
+  const player = pillarbox(
+    'video-element-id',
+    {
+      muted: true,
+      plugins: { qualityMenu: true }
+    }
+  );
 
   // Load the video source
   player.src({ src: 'urn:srf:video:593535b2-87c0-433a-8d2c-baf819233df1', type: 'srgssr/urn' });

--- a/static/showcases/skip-credits.html
+++ b/static/showcases/skip-credits.html
@@ -27,7 +27,13 @@
   import '@srgssr/skip-button';
 
   // Create a pillarbox player instance with the skip-button component
-  const player = pillarbox('video-element-id', { SkipButton: true });
+  const player = pillarbox(
+    'video-element-id',
+    {
+      muted: true,
+      SkipButton: true
+    }
+  );
 
   // Load the video source for the player
   player.src({ src: 'urn:rts:video:15532586', type: 'srgssr/urn' });

--- a/static/showcases/start-time.html
+++ b/static/showcases/start-time.html
@@ -24,7 +24,7 @@
   import pillarbox from '@srgssr/pillarbox-web';
 
   // Create by referencing the video element with its unique ID
-  const player = pillarbox('video-element-id');
+  const player = pillarbox('video-element-id', { muted: true });
 
   // Load the video source
   player.src({ src: 'urn:rts:video:6820736', type: 'srgssr/urn' });


### PR DESCRIPTION
## Description

Resolves #68 by muting all showcases' content by default for a quieter testing experience.