### PR TITLE
refactor(thumbnail-preview): simplify access to spriteSheet property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@srgssr/pillarbox-playlist": "^2.2.0",
-        "@srgssr/pillarbox-web": "^1.23.3",
+        "@srgssr/pillarbox-web": "^1.24.0",
         "@srgssr/skip-button": "^1.1.0",
         "@srgssr/thumbnail-preview": "^1.0.2",
         "highlight.js": "^11.11.1",
@@ -2154,9 +2154,9 @@
       }
     },
     "node_modules/@srgssr/pillarbox-web": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@srgssr/pillarbox-web/-/pillarbox-web-1.23.3.tgz",
-      "integrity": "sha512-xWLBDf8QVlukUub7LMOrVOwnoVMLDs+iqeAYyYqFQULrWIJSoXmGCEfMN0VXKJlFG0bURP+uVTs6MgWa7w5CyA==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@srgssr/pillarbox-web/-/pillarbox-web-1.24.0.tgz",
+      "integrity": "sha512-M6Kb0G3dB03PBzGum640M9Fwt3cINGmogH0ZtlY+09s2ilmUgYj5NcpSh/u28jW4eL8U1njYYiUNoupjtkeDhQ==",
       "license": "MIT",
       "dependencies": {
         "videojs-contrib-eme": "5.5.2"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@srgssr/pillarbox-playlist": "^2.2.0",
-    "@srgssr/pillarbox-web": "^1.23.3",
+    "@srgssr/pillarbox-web": "^1.24.0",
     "@srgssr/skip-button": "^1.1.0",
     "@srgssr/thumbnail-preview": "^1.0.2",
     "highlight.js": "^11.11.1",

--- a/static/showcases/thumbnail-preview.html
+++ b/static/showcases/thumbnail-preview.html
@@ -35,8 +35,6 @@
     const spriteSheet = player
       .currentSource()
       .mediaData
-      ?.chapters
-      ?.find(chapter => chapter.urn === 'urn:rts:video:15532586')
       ?.spriteSheet;
 
     // Set the sprite of the thumbnail preview plugin


### PR DESCRIPTION




## Description
This refactor is possible thanks to the new release of pillarbox-web, which exposes the `spriteSheet` property directly on `mediaData` and improves developer experience. There is no longer any need to check for chapters and then find the chapter by its URN to get the `spriteSheet`.
## Changes made
- update pillarbox-web to 1.24.0
- update showcase example
