### PR TITLE
feat(header): add link to monitoring

### DIFF
--- a/src/layout/header/demo-header-component.js
+++ b/src/layout/header/demo-header-component.js
@@ -81,6 +81,13 @@ export class DemoHeaderElement extends LitElement {
               Showcase
             </route-link>
           </li>
+          <li part="monitoring-li">
+            <a href="https://grafana.pillarbox.ch/"
+               title="Monitoring" part="monitoring-link"
+               target="_blank" rel="noopener noreferrer">
+              <i class="material-symbols-outlined">bar_chart</i>
+            </a>
+          </li>
         </ul>
       </nav>`;
   }

--- a/src/layout/header/demo-header-component.scss
+++ b/src/layout/header/demo-header-component.scss
@@ -49,4 +49,20 @@ demo-header {
     }
   }
 
+  [part="monitoring-li"] {
+    margin-left: auto;
+  }
+
+  [part="monitoring-link"] {
+    color: var(--color-6);
+    text-decoration: none;
+
+    i {
+      font-size: var(--size-6);
+    }
+
+    &:hover {
+      color: var(--color-1);
+    }
+  }
 }


### PR DESCRIPTION
## Description

Resolves #83 by adding a link to the monitoring tool to make it easier to access.

## Changes made

- added an `li` in `renderNavElement` with a link pointing to the monitoring tool
- added CSS classes to style the link

