### PR TITLE
fix(header): move monitorign link to the top header element

### DIFF
--- a/src/layout/header/core-demo-header-component.scss
+++ b/src/layout/header/core-demo-header-component.scss
@@ -1,6 +1,5 @@
 header {
   display: flex;
-  align-items: baseline;
   justify-content: space-between;
   width: 100%;
   margin: var(--size-4) 0;
@@ -33,4 +32,14 @@ h1 {
 [part="header-end"] {
   display: flex;
   align-items: center;
+}
+
+@media (width < 768px) {
+  [part="brand-logo"] {
+    height: var(--size-5);
+  }
+
+  h1 {
+    font-size: var(--size-5);
+  }
 }

--- a/src/layout/header/demo-header-component.js
+++ b/src/layout/header/demo-header-component.js
@@ -55,6 +55,10 @@ export class DemoHeaderElement extends LitElement {
                     title="Settings" slot="actions">
           <i class="material-symbols-outlined">settings</i>
         </route-link>
+        <a href="https://grafana.pillarbox.ch/" title="Monitoring"
+           target="_blank" rel="noopener noreferrer" slot="actions">
+          <i class="material-symbols-outlined">bar_chart</i>
+        </a>
       </core-demo-header>
     `;
   }
@@ -80,13 +84,6 @@ export class DemoHeaderElement extends LitElement {
             <route-link href="showcase${this.debug ? '?debug=true' : ''}">
               Showcase
             </route-link>
-          </li>
-          <li part="monitoring-li">
-            <a href="https://grafana.pillarbox.ch/"
-               title="Monitoring" part="monitoring-link"
-               target="_blank" rel="noopener noreferrer">
-              <i class="material-symbols-outlined">bar_chart</i>
-            </a>
           </li>
         </ul>
       </nav>`;

--- a/src/layout/header/demo-header-component.scss
+++ b/src/layout/header/demo-header-component.scss
@@ -1,4 +1,8 @@
+@use "../../../scss/theme-mixin";
+
 demo-header {
+  @include theme-mixin.base-theme-mixin;
+
   ul, li {
     margin: 0;
     padding: 0;
@@ -24,13 +28,17 @@ demo-header {
     display: flex;
     align-items: center;
 
-    route-link {
+    route-link, a {
       margin-left: var(--size-2);
     }
 
-    route-link::part(a) {
+    route-link::part(a), a {
       display: flex;
       align-items: center;
+      text-decoration: none;
+    }
+
+    a:hover {
       text-decoration: none;
     }
 
@@ -46,23 +54,6 @@ demo-header {
 
     li {
       margin: 0;
-    }
-  }
-
-  [part="monitoring-li"] {
-    margin-left: auto;
-  }
-
-  [part="monitoring-link"] {
-    color: var(--color-6);
-    text-decoration: none;
-
-    i {
-      font-size: var(--size-6);
-    }
-
-    &:hover {
-      color: var(--color-1);
     }
   }
 }


### PR DESCRIPTION
## Description

Remove the monitoring link from the nav element and move it to the core header. This element was overlapping with the rest of the links on narrow views, such as phones in portrait mode.

| Before | After |
|--------|-------|
| <img width="379" height="273" alt="image" src="https://github.com/user-attachments/assets/a298b665-df69-49ce-b875-bb90516483ba" />| <img width="376" height="265" alt="image" src="https://github.com/user-attachments/assets/a00ce05a-54aa-4c21-80d4-0b65e991e68e" /> |

## Changes made

- Moved the monitoring link from the nav list to the top header.
- Added a media query to shrink the title on mobile, leaving room for more elements.
