### PR TITLE
refactor: countdown showcase to use @srgssr/countdown-display component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@srgssr/countdown-display": "^1.0.0",
         "@srgssr/pillarbox-playlist": "^3.3.0",
-        "@srgssr/pillarbox-web": "^1.24.1",
+        "@srgssr/pillarbox-web": "^1.31.0",
         "@srgssr/skip-button": "^1.1.0",
         "@srgssr/thumbnail-preview": "^1.0.3",
         "highlight.js": "^11.11.1",
@@ -2284,6 +2285,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@srgssr/card/-/card-1.0.1.tgz",
       "integrity": "sha512-POgBSy7f/YELTZiM12O24pV1HqRYL1kJM6IdvNtWOqZP2Zr7XQwMmtbnxSRsF7OFOSaX1/XCrk9adxdH4dRPgw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "video.js": "^8.0.0"
+      }
+    },
+    "node_modules/@srgssr/countdown-display": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@srgssr/countdown-display/-/countdown-display-1.0.0.tgz",
+      "integrity": "sha512-AV/GX0BZNJgxZMcVRp4IuyXd9xNrQPSj65qTL7p/AClAqQeByE7hZ/c3N/R0TxWfSYDhrgPQrhMh7eqxsrcI8g==",
       "license": "MIT",
       "peerDependencies": {
         "video.js": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
     "vite": "^7.2.2"
   },
   "dependencies": {
+    "@srgssr/countdown-display": "^1.0.0",
     "@srgssr/pillarbox-playlist": "^3.3.0",
-    "@srgssr/pillarbox-web": "^1.24.1",
+    "@srgssr/pillarbox-web": "^1.31.0",
     "@srgssr/skip-button": "^1.1.0",
     "@srgssr/thumbnail-preview": "^1.0.3",
     "highlight.js": "^11.11.1",

--- a/src/layout/content/showcase/showcases.js
+++ b/src/layout/content/showcase/showcases.js
@@ -69,7 +69,7 @@ export const showcases= [
     id: 'countdown',
     href: 'countdown.html',
     title: 'Countdown Timer',
-    description: html`In this showcase, we'll demonstrate how to display a countdown timer.`,
+    description: html`In this showcase, we'll demonstrate how to display a countdown timer using the <a href="https://github.com/SRGSSR/pillarbox-web-suite/tree/main/packages/countdown-display#readme" target="_blank">@srgssr/countdown-display</a> component.`,
     code: getTextFromHTML(rawCountdown),
   },
   {

--- a/static/showcases/countdown.html
+++ b/static/showcases/countdown.html
@@ -24,153 +24,12 @@
     <script type="module" data-implementation>
       // Import the pillarbox library
       import pillarbox from '@srgssr/pillarbox-web';
+      import '@srgssr/countdown-display';
 
-      const ModalDialog = pillarbox.getComponent('ModalDialog');
-
-      /**
-       * Provides a countdown timer functionality within a modal dialog.
-       */
-      class Countdown extends ModalDialog {
-        /**
-         * Creates an instance of Countdown.
-         *
-         * @param {Player} player The video.js player instance
-         * @param {Object} options Configuration options for the modal dialog
-         */
-        constructor(player, options) {
-          const opts = pillarbox.obj.merge(options, {
-            pauseOnOpen: false,
-            fillAlways: true,
-            temporary: false,
-            uncloseable: true
-          });
-
-          super(player, opts);
-
-          this.intervalId = undefined;
-          this.reset = this.reset.bind(this);
-
-          this.on(player, ['loadstart', 'playerreset', 'dispose', 'error'], this.reset);
-        }
-
-        /**
-         * The CSS class name for the countdown modal dialog.
-         *
-         * @returns {string} The CSS class name
-         */
-        buildCSSClass() {
-          return `pillarbox-countdown ${super.buildCSSClass()}`;
-        }
-
-        /**
-         * Disposes of the countdown component.
-         *
-         * Cleans up any resources and event listeners.
-         */
-        dispose() {
-          this.reset();
-          this.off(this.player(), ['loadstart', 'playerreset', 'dispose', 'error'], this.reset);
-
-          super.dispose();
-        }
-
-        /**
-         * Resets the countdown timer.
-         *
-         * Clears the interval, closes the modal, and empties its content.
-         */
-        reset() {
-          this.clearInterval(this.intervalId);
-          this.close();
-          this.empty();
-
-          this.intervalId = undefined;
-        }
-
-        /**
-         * Starts the countdown timer.
-         *
-         * @param {number} timestamp The target timestamp in milliseconds
-         * @param {string} source The source to play when the countdown ends
-         *
-         * @returns {boolean} True if the countdown started successfully
-         */
-        start(timestamp, source) {
-          this.reset();
-
-          if (typeof timestamp !== 'number') return;
-
-          this.intervalId = this.setInterval(() => {
-            const remainingDuration = this.remainingDuration(timestamp);
-
-            if (remainingDuration.totalInMilliseconds <= 0) {
-              this.reset();
-              this.player().src(source);
-
-              return;
-            }
-
-            this.fillWith(`${remainingDuration.days
-              }d ${remainingDuration.hours
-              }h ${remainingDuration.minutes
-              }m ${remainingDuration.seconds
-              }s remaining`);
-          }, 1_000);
-
-          this.open();
-
-          return true;
-        }
-
-        /**
-         * The remaining duration until the target timestamp.
-         *
-         * @param {number} timestamp The target timestamp in milliseconds
-         *
-         * @returns {Object} An object containing the remaining days, hours, minutes, seconds, and total in milliseconds
-         */
-        remainingDuration(timestamp) {
-          const SECONDS_IN_MS = 1_000;
-          const MINUTES = 60 * SECONDS_IN_MS;
-          const HOURS = 60 * MINUTES;
-          const DAYS = 24 * HOURS;
-          const totalInMilliseconds = timestamp - Date.now();
-
-          let diff = totalInMilliseconds;
-          // Calculate days, hours, minutes, and seconds
-          let days = Math.floor(diff / DAYS);
-          diff -= days * DAYS;
-
-          let hours = Math.floor(diff / HOURS);
-          diff -= hours * HOURS;
-
-          let minutes = Math.floor(diff / MINUTES);
-          diff -= minutes * MINUTES;
-
-          let seconds = Math.floor(diff / SECONDS_IN_MS);
-
-          return {
-            days: days.toString().padStart(2, '0'),
-            hours: hours.toString().padStart(2, '0'),
-            minutes: minutes.toString().padStart(2, '0'),
-            seconds: seconds.toString().padStart(2, '0'),
-            totalInMilliseconds
-          }
-        }
-      }
-
-      // Register Countdown component
-      pillarbox.registerComponent('Countdown', Countdown);
-
-      // Create a pillarbox player instance with the countdown component
+      // Create a pillarbox player instance with the countdown display component
       const player = pillarbox(
         'video-element-id',
-        {
-          muted: true,
-          fill: true,
-          // Add the countdown component to the player
-          countdown: true,
-        }
+        { muted: true, countdownDisplay: true, }
       );
 
       // Listen for player errors
@@ -185,23 +44,23 @@
         const {
           src: {
             mediaData: {
-              chapters: [{ validFrom } = {}] = []
+              validFrom
             } = {}
           } = {}
         } = metadata;
         const timestamp = new Date(validFrom).getTime();
 
-        if (!player.countdown.start(timestamp, player.currentSource())) return;
-
         // Closes error display component to prevent overlapping
         if (player.errorDisplay && player.errorDisplay.opened()) {
           player.errorDisplay.close();
         }
+
+        player.countdownDisplay.start(timestamp, player.currentSource())
       });
 
       // In the absence of media generating a STARTDATE error, this function
       // manually activates the countdown
-      player.countdown.start(Date.now() + 5_977_235_000, { src: 'urn:rts:video:10894383', type: 'srgssr/urn' });
+      player.countdownDisplay.start(Date.now() + 5_977_235_000, { src: 'urn:rts:video:10894383', type: 'srgssr/urn' });
 
       // If a media sends a STARTDATE error, the countdown is automatically
       // activated, since the logic for activating the countdown is handled by

--- a/static/showcases/countdown.scss
+++ b/static/showcases/countdown.scss
@@ -1,11 +1,2 @@
 @use 'static-showcase';
-
-
-.pillarbox-countdown .vjs-modal-dialog-content {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: bold;
-  font-size: 2em;
-  text-align: center;
-}
+@import '@srgssr/countdown-display/dist/countdown-display.min.css';


### PR DESCRIPTION
## Description

Resolves #92 by updating the existing countdown showcase to use the @srgssr/countdown-display from the [pillarbox-web-suite](https://github.com/SRGSSR/pillarbox-web-suite/)

## Changes made

- Updated the pillarbox version to 1.31.0 to use the new exposed `validFrom` and `validTo` properties in the example. See https://github.com/SRGSSR/pillarbox-web/pull/359


