### PR TITLE
style: fix minor style issues in showcase page

### DIFF
--- a/src/layout/content/showcase/showcase-component.js
+++ b/src/layout/content/showcase/showcase-component.js
@@ -76,6 +76,8 @@ export class ShowcaseComponent extends LitElement {
             </div>
           `)}
         </div>
+
+        <slot name="action"></slot>
       </div>
     `;
   }

--- a/src/layout/content/showcase/showcase-page.js
+++ b/src/layout/content/showcase/showcase-page.js
@@ -13,34 +13,34 @@ export class ShowCasePage extends LitElement {
 
   render() {
     return html`
-      ${map(showcases ?? [], this.#renderItem.bind(this))}
+      <div class="fade-in"
+           @animationend="${e => e.target.classList.remove('fade-in')}">
+        ${map(showcases ?? [], this.#renderItem.bind(this))}
+      </div>
     `;
   }
 
 
   #renderItem({ id, href, title, description, code }) {
     return html`
-      <div class="fade-in"
-           @animationend="${e => e.target.classList.remove('fade-in')}">
-        <showcase-component href="${href}">
-          <a id="${id}" href="#${id}" slot="title" part="anchor-title">
-            <h2>${title}</h2>
-          </a>
-          <p slot="description">${description}</p>
-          <span slot="toggle-collapsed">
+      <showcase-component href="${href}">
+        <a id="${id}" href="#${id}" slot="title" part="anchor-title">
+          <h2>${title}</h2>
+        </a>
+        <p slot="description">${description}</p>
+        <span slot="toggle-collapsed">
             <i class="material-symbols-outlined">visibility</i> See the Implementation
           </span>
-          <span slot="toggle-expanded">
+        <span slot="toggle-expanded">
             <i class="material-symbols-outlined">visibility_off</i> Hide the Implementation
           </span>
-          <code-block slot="code" language="javascript">${code}</code-block>
-        </showcase-component>
-        <a part="showcase-link"
+        <code-block slot="code" language="javascript">${code}</code-block>
+        <a slot="action" part="showcase-link"
            href="./static/showcases/${href}"
            target="_blank">
           Open this showcase
         </a>
-      </div>
+      </showcase-component>
     `;
   }
 }

--- a/src/layout/content/showcase/showcase-page.scss
+++ b/src/layout/content/showcase/showcase-page.scss
@@ -11,38 +11,31 @@ showcase-page {
 
   [part="showcase-link"] {
     display: flex;
-    flex-direction: column;
-    gap: var(--size-2);
+    align-items: center;
     justify-content: center;
     min-height: var(--size-9);
-    margin: 0;
-    color: var(--color-0);
     font-weight: var(--font-weight-6);
     font-size: var(--size-3);
-    text-align: center;
     text-decoration: none;
     background-color: var(--color-9);
-    border: 1px solid var(--color-10);
     border-radius: var(--radius-2);
-    transition: background-color 0.4s, border-color 0.4s;
-    padding-inline: var(--size-3);
+    transition: background-color 0.4s;
 
     &:hover {
       text-decoration: none;
       background-color: var(--color-8);
-      border-color: var(--color-9);
     }
   }
 
-  div {
+  showcase-component {
     margin-top: var(--size-7);
+
+    a {
+      font-size: inherit;
+    }
   }
 
-  div:last-child {
+  showcase-component:last-child {
     margin-bottom: var(--size-7);
-  }
-
-  a {
-    font-size: inherit;
   }
 }


### PR DESCRIPTION
## Description

Minor style and structural changes to optimize the showcase page and fix some style issues.

## Changes made

- Fix the font size of links in the showcase to make them consistent with the container they are in.
- Move the startup fade-in animation to the topmost element of the showcase page so that only one element is animated instead of multiple.
- Move the `showcase-link` inside the `showcase-component` to encapsulate all elements under the same container.