### PR TITLE
ci: pin third-party github actions to immutable commit hashes

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -30,7 +30,7 @@ jobs:
           npm run build
 
       - name: Deploy GitHub Page 🚀
-        uses: JamesIves/github-pages-deploy-action@releases/v4
+        uses: JamesIves/github-pages-deploy-action@800bbc83122db9d4c38fcd284782d5afe62e52df # releases/v4
         with:
           branch: gh-pages
           folder: dist

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -37,7 +37,7 @@ jobs:
           npm run build
 
       - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1
         with:
           source-dir: dist
           preview-branch: gh-pages


### PR DESCRIPTION
## Description

Following GitHub's security best practices, this change ensures that workflow executions use an exact hash instead of a tag.

Unlike tags, commit hashes are immutable, protecting the repository against "tag shifting" where a malicious actor or a compromised maintainer could overwrite a version tag (e.g., @v1) with malicious code.

Ref: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Changes made

- Pinned third-party actions to specific SHAs.
- Added the original tag as a comment for readability.
- Skipped first-party `actions/*` repositories as they are trusted.