### PR TITLE
chore(deps): add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,79 @@
+version: 2
+updates:
+  # --- GitHub Actions ---
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      action-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- NPM: demo ---
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      node-dependencies:
+        patterns: [ "*" ]
+        update-types: [ "minor", "patch" ]
+
+  # --- NPM: samples ---
+  - package-ecosystem: "npm"
+    directory: "/samples/angular"
+    schedule:
+      interval: "weekly"
+    groups:
+      node-dependencies:
+        patterns: [ "*" ]
+        update-types: [ "minor", "patch" ]
+
+  - package-ecosystem: "npm"
+    directory: "/samples/lightningjs"
+    schedule:
+      interval: "weekly"
+    groups:
+      node-dependencies:
+        patterns: [ "*" ]
+        update-types: [ "minor", "patch" ]
+
+  - package-ecosystem: "npm"
+    directory: "/samples/react"
+    schedule:
+      interval: "weekly"
+    groups:
+      node-dependencies:
+        patterns: [ "*" ]
+        update-types: [ "minor", "patch" ]
+
+  - package-ecosystem: "npm"
+    directory: "/samples/umd"
+    schedule:
+      interval: "weekly"
+    groups:
+      node-dependencies:
+        patterns: [ "*" ]
+        update-types: [ "minor", "patch" ]
+
+  - package-ecosystem: "npm"
+    directory: "/samples/vanilla-ts"
+    schedule:
+      interval: "weekly"
+    groups:
+      node-dependencies:
+        patterns: [ "*" ]
+        update-types: [ "minor", "patch" ]
+
+  - package-ecosystem: "npm"
+    directory: "/samples/vue"
+    schedule:
+      interval: "weekly"
+    groups:
+      node-dependencies:
+        patterns: [ "*" ]
+        update-types: [ "minor", "patch" ]


### PR DESCRIPTION
## Description

Add `.github/dependabot.yml` to automate dependency updates across the repository. The configuration is split into separate entries to keep PRs isolated per sample:

- GitHub Actions: one entry at the root, grouping minor/patch updates.
- NPM (demo): one entry at `/`, covering the root `package.json`.
- NPM (samples): one entry per sample, each independently grouped.