### PR TITLE
ci: skip PR preview deploy for Dependabot and set explicit permissions

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -9,6 +9,10 @@ jobs:
   github-page:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,6 +12,12 @@ concurrency: preview-${{ github.ref }}
 
 jobs:
   deploy-preview:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+
+    permissions:
+      contents: write
+      pull-requests: write
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,6 +10,10 @@ jobs:
   quality:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Description

Dependabot triggered pull requests fail to run pr-preview-action with a 403 and the workflow reports as failed, blocking the merge.

## Changes made

- Add a skip to the preview job when the actor is dependabot.
- Declare explicit permissions on all workflows.
