### PR TITLE
chore(deps): ignore all angular versions in dependanbot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,14 +34,11 @@ updates:
     ignore:
       - dependency-name: "@srgssr/*"
       - dependency-name: "video.js"
-      # Angular majors require running `ng update` migrations manually,
-      # and typescript/rxjs majors must stay within Angular's supported range.
+      # Angular versions require running `ng update` migrations manually,
+      # and typescript/rxjs must stay within Angular's supported range.
       - dependency-name: "@angular/*"
-        update-types: [ "version-update:semver-major" ]
       - dependency-name: "typescript"
-        update-types: [ "version-update:semver-major" ]
       - dependency-name: "rxjs"
-        update-types: [ "version-update:semver-major" ]
     groups:
       node-dependencies:
         patterns: [ "*" ]


### PR DESCRIPTION
## Description

Forces depandabot to ignore all angular dependencies and its dependencies that must stays within angular supported range.

